### PR TITLE
Update results.csv

### DIFF
--- a/tools-report/rmlstreamer-static/results.csv
+++ b/tools-report/rmlstreamer-static/results.csv
@@ -219,7 +219,7 @@ RMLTC0010b-PostgreSQL,inapplicable
 RMLTC0010b-SQLServer,inapplicable
 RMLTC0010b-XML,passed
 RMLTC0010c-CSV,passed
-RMLTC0010c-JSON,fassed
+RMLTC0010c-JSON,passed
 RMLTC0010c-MySQL,inapplicable
 RMLTC0010c-PostgreSQL,inapplicable
 RMLTC0010c-SQLServer,inapplicable


### PR DESCRIPTION
Fixed typo, resulting in `RMLTC0010c-JSON,passed` not being reported.